### PR TITLE
Add return types for Nextcloud 30 compatibility

### DIFF
--- a/lib/Controller/TemplateResponsePatch.php
+++ b/lib/Controller/TemplateResponsePatch.php
@@ -9,7 +9,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 /** @psalm-suppress MissingTemplateParam */
 class TemplateResponsePatch extends TemplateResponse
 {
-    public function render()
+    public function render(): string
     {
         $content = parent::render();
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -16,7 +16,7 @@ class Admin implements ISettings
     /**
      * @return TemplateResponse
      */
-    public function getForm()
+    public function getForm(): TemplateResponse
     {
         \OCP\Util::addScript(Application::APPNAME, 'memories-admin');
 
@@ -26,7 +26,7 @@ class Admin implements ISettings
     /**
      * @return string
      */
-    public function getSection()
+    public function getSection(): string
     {
         return Application::APPNAME;
     }
@@ -34,7 +34,7 @@ class Admin implements ISettings
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 50;
     }

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -19,7 +19,7 @@ class AdminSection implements IIconSection
     /**
      * @return TemplateResponse
      */
-    public function getForm()
+    public function getForm(): TemplateResponse
     {
         return new TemplateResponse('memories', 'admin', []);
     }
@@ -27,7 +27,7 @@ class AdminSection implements IIconSection
     /**
      * @return string
      */
-    public function getID()
+    public function getID(): string
     {
         return 'memories';
     }
@@ -35,7 +35,7 @@ class AdminSection implements IIconSection
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->l->t('Memories');
     }
@@ -43,7 +43,7 @@ class AdminSection implements IIconSection
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 75;
     }
@@ -51,7 +51,7 @@ class AdminSection implements IIconSection
     /**
      * @return string
      */
-    public function getIcon()
+    public function getIcon(): string
     {
         return $this->urlGenerator->imagePath('memories', 'app-dark.svg');
     }


### PR DESCRIPTION
## Summary
- add the missing return type declaration to TemplateResponsePatch::render()
- declare return types on the admin settings classes to match the updated Nextcloud interfaces

## Testing
- php -l lib/Controller/TemplateResponsePatch.php
- php -l lib/Settings/Admin.php
- php -l lib/Settings/AdminSection.php

------
https://chatgpt.com/codex/tasks/task_e_68db74834f088330ab4e71a02ea34fc1